### PR TITLE
add Test for NodeCandidateConverter

### DIFF
--- a/src/main/java/io/github/cloudiator/rest/converter/TaskInterfaceConverter.java
+++ b/src/main/java/io/github/cloudiator/rest/converter/TaskInterfaceConverter.java
@@ -19,9 +19,11 @@ public class TaskInterfaceConverter implements
     switch (taskInterface.getTaskInterfaceCase()) {
       case LANCEINTERFACE:
         result = lanceInterfaceConverter.applyBack(taskInterface.getLanceInterface());
+        result.setType(taskInterface.getLanceInterface().getClass().getSimpleName());
         break;
       case DOCKERINTERFACE:
         result = dockerInterfaceConverter.applyBack(taskInterface.getDockerInterface());
+        result.setType(taskInterface.getDockerInterface().getClass().getSimpleName());
         break;
       case TASKINTERFACE_NOT_SET:
       default:

--- a/src/test/java/io/github/cloudiator/rest/converter/CloudToCloudConverterTest.java
+++ b/src/test/java/io/github/cloudiator/rest/converter/CloudToCloudConverterTest.java
@@ -11,8 +11,8 @@ import static org.hamcrest.Matchers.*;
 public class CloudToCloudConverterTest {
 
     private final CloudToCloudConverter cloudConverter = new CloudToCloudConverter();
-    private final Cloud restCloud;
-    private final IaasEntities.Cloud iaasCloud;
+    public final Cloud restCloud;
+    public final IaasEntities.Cloud iaasCloud;
     //Api
     private final Api restApi;
     private final IaasEntities.Api iaasApi;

--- a/src/test/java/io/github/cloudiator/rest/converter/HardwareConverterTest.java
+++ b/src/test/java/io/github/cloudiator/rest/converter/HardwareConverterTest.java
@@ -12,52 +12,52 @@ import static org.junit.Assert.*;
 
 public class HardwareConverterTest {
 
-    private final HardwareConverter hardwareConverter = new HardwareConverter();
-    //hardware
-    private final Hardware restHardware;
-    private final IaasEntities.HardwareFlavor iaasHardware;
+  private final HardwareConverter hardwareConverter = new HardwareConverter();
+  //hardware
+  public final Hardware restHardware;
+  public final IaasEntities.HardwareFlavor iaasHardware;
+  //Location
+  private final Location restLoacation;
+  private final IaasEntities.Location iaasLocation;
+
+  public HardwareConverterTest() {
     //Location
-    private final Location restLoacation;
-    private final IaasEntities.Location iaasLocation;
+    this.restLoacation = new Location().name("TestName")
+        .id("32chars-long_testID_for_UnitTest")
+        .providerId("TestProviderId")
+        .locationScope(Location.LocationScopeEnum.PROVIDER)
+        .isAssignable(true);
+    this.iaasLocation = IaasEntities.Location.newBuilder()
+        .setName("TestName")
+        .setId("32chars-long_testID_for_UnitTest")
+        .setProviderId("TestProviderId")
+        .setLocationScope(CommonEntities.LocationScope.PROVIDER)
+        .setIsAssignable(true)
+        .clearParent().build();
+    //Hardware
+    this.restHardware = new Hardware().cores(4).disk((float) 256).ram((long) 2048)
+        .name("TestName").id("32chars-long_testID_for_UnitTest")
+        .providerId("TestProviderId")
+        .location(restLoacation);
+    this.iaasHardware = IaasEntities.HardwareFlavor.newBuilder()
+        .setCores(4).setDisk(256).setRam(2048)
+        .setName("TestName").setId("32chars-long_testID_for_UnitTest")
+        .setProviderId("TestProviderId")
+        .setLocation(iaasLocation).build();
+  }
 
-    public HardwareConverterTest() {
-        //Location
-        this.restLoacation = new Location().name("TestName")
-                .id("32chars-long_testID_for_UnitTest")
-                .providerId("TestProviderId")
-                .locationScope(Location.LocationScopeEnum.PROVIDER)
-                .isAssignable(true);
-        this.iaasLocation = IaasEntities.Location.newBuilder()
-                .setName("TestName")
-                .setId("32chars-long_testID_for_UnitTest")
-                .setProviderId("TestProviderId")
-                .setLocationScope(CommonEntities.LocationScope.PROVIDER)
-                .setIsAssignable(true)
-                .clearParent().build();
-        //Hardware
-        this.restHardware = new Hardware().cores(4).disk((float)256).ram((long)2048)
-                .name("TestName").id("32chars-long_testID_for_UnitTest")
-                .providerId("TestProviderId")
-                .location(restLoacation);
-        this.iaasHardware = IaasEntities.HardwareFlavor.newBuilder()
-                .setCores(4).setDisk(256).setRam(2048)
-                .setName("TestName").setId("32chars-long_testID_for_UnitTest")
-                .setProviderId("TestProviderId")
-                .setLocation(iaasLocation).build();
-    }
+  @Test
+  public void applyBack() throws Exception {
+    //from iaas to rest
+    Hardware actual = hardwareConverter.applyBack(iaasHardware);
+    assertThat(actual, is(equalTo(restHardware)));
+  }
 
-    @Test
-    public void applyBack() throws Exception {
-        //from iaas to rest
-        Hardware actual = hardwareConverter.applyBack(iaasHardware);
-        assertThat(actual, is(equalTo(restHardware)));
-    }
-
-    @Test
-    public void apply() throws Exception {
-        //from rest to iaas
-        IaasEntities.HardwareFlavor actual = hardwareConverter.apply(restHardware);
-        assertThat(actual, is(equalTo(iaasHardware)));
-    }
+  @Test
+  public void apply() throws Exception {
+    //from rest to iaas
+    IaasEntities.HardwareFlavor actual = hardwareConverter.apply(restHardware);
+    assertThat(actual, is(equalTo(iaasHardware)));
+  }
 
 }

--- a/src/test/java/io/github/cloudiator/rest/converter/ImageConverterTest.java
+++ b/src/test/java/io/github/cloudiator/rest/converter/ImageConverterTest.java
@@ -11,8 +11,8 @@ import static org.junit.Assert.*;
 public class ImageConverterTest {
 
     private final ImageConverter imageConverter = new ImageConverter();
-    private final Image restImage;
-    private final IaasEntities.Image iaasImage;
+    public final Image restImage;
+    public final IaasEntities.Image iaasImage;
     //Operatingsystem
     private final OperatingSystem restOperatingSystem;
     private final CommonEntities.OperatingSystem iaasOperatingSystem;

--- a/src/test/java/io/github/cloudiator/rest/converter/JobConverterTest.java
+++ b/src/test/java/io/github/cloudiator/rest/converter/JobConverterTest.java
@@ -92,6 +92,7 @@ public class JobConverterTest {
     //Interfaces
     this.restDockerInterface = new DockerInterface()
         .dockerImage("DockerImage");
+    this.restDockerInterface.setType(restDockerInterface.getClass().getSimpleName());
     this.iaasTaskDockerInterface = TaskEntities.TaskInterface.newBuilder()
         .setDockerInterface(
             TaskEntities.DockerInterface.newBuilder()
@@ -102,6 +103,7 @@ public class JobConverterTest {
         .startDetection("startDetection").preStart("preStart").start("start").postStart("postStart")
         .stopDetection("stopDetection").preStop("preStop").stop("stop").postStop("postStop")
         .shutdown("shutdown");
+    this.restLanceInterface.setType(restLanceInterface.getClass().getSimpleName());
     this.iaasTaskLanceInterface = TaskEntities.TaskInterface.newBuilder()
         .setLanceInterface(
             TaskEntities.LanceInterface.newBuilder()

--- a/src/test/java/io/github/cloudiator/rest/converter/LocationConverterTest.java
+++ b/src/test/java/io/github/cloudiator/rest/converter/LocationConverterTest.java
@@ -10,70 +10,70 @@ import static org.junit.Assert.*;
 
 public class LocationConverterTest {
 
-    private final LocationConverter locationConverter = new LocationConverter();
-    private final Location restLocation;
-    private final IaasEntities.Location iaasLocation;
-    private final Location restParentLocation;
-    private final IaasEntities.Location iaasParentLocation;
+  private final LocationConverter locationConverter = new LocationConverter();
+  public final Location restLocation;
+  public final IaasEntities.Location iaasLocation;
+  public final Location restParentLocation;
+  public final IaasEntities.Location iaasParentLocation;
 
-    public LocationConverterTest() {
-        this.iaasParentLocation = IaasEntities.Location.newBuilder()
-                .setId("32chars-long_testID_for_UnitTest")
-                .setName("TestName")
-                .setLocationScope(CommonEntities.LocationScope.PROVIDER)
-                .setProviderId("TestProvider")
-                .setIsAssignable(true)
-                .clearParent().build();
-        this.restParentLocation = new Location()
-                .id("32chars-long_testID_for_UnitTest")
-                .name("TestName")
-                .locationScope(Location.LocationScopeEnum.PROVIDER)
-                .providerId("TestProvider")
-                .isAssignable(true);
-        this.iaasLocation = IaasEntities.Location.newBuilder()
-                .setId("32chars-long_testID_for_UnitTest")
-                .setName("TestName")
-                .setLocationScope(CommonEntities.LocationScope.PROVIDER)
-                .setProviderId("TestProvider")
-                .setIsAssignable(true)
-                .setParent(iaasParentLocation).build();
-        this.restLocation = new Location()
-                .id("32chars-long_testID_for_UnitTest")
-                .name("TestName")
-                .locationScope(Location.LocationScopeEnum.PROVIDER)
-                .providerId("TestProvider")
-                .parent(restParentLocation)
-                .isAssignable(true);
-    }
+  public LocationConverterTest() {
+    this.iaasParentLocation = IaasEntities.Location.newBuilder()
+        .setId("32chars-long_testID_for_UnitTest")
+        .setName("TestName")
+        .setLocationScope(CommonEntities.LocationScope.PROVIDER)
+        .setProviderId("TestProvider")
+        .setIsAssignable(true)
+        .clearParent().build();
+    this.restParentLocation = new Location()
+        .id("32chars-long_testID_for_UnitTest")
+        .name("TestName")
+        .locationScope(Location.LocationScopeEnum.PROVIDER)
+        .providerId("TestProvider")
+        .isAssignable(true);
+    this.iaasLocation = IaasEntities.Location.newBuilder()
+        .setId("32chars-long_testID_for_UnitTest")
+        .setName("TestName")
+        .setLocationScope(CommonEntities.LocationScope.PROVIDER)
+        .setProviderId("TestProvider")
+        .setIsAssignable(true)
+        .setParent(iaasParentLocation).build();
+    this.restLocation = new Location()
+        .id("32chars-long_testID_for_UnitTest")
+        .name("TestName")
+        .locationScope(Location.LocationScopeEnum.PROVIDER)
+        .providerId("TestProvider")
+        .parent(restParentLocation)
+        .isAssignable(true);
+  }
 
-    @Test
-    public void applyBack_withoutParent() throws Exception {
-        //from iaas to rest
-        Location actual = locationConverter.applyBack(iaasParentLocation);
-        assertThat(actual, is(equalTo(restParentLocation)));
-    }
+  @Test
+  public void applyBack_withoutParent() throws Exception {
+    //from iaas to rest
+    Location actual = locationConverter.applyBack(iaasParentLocation);
+    assertThat(actual, is(equalTo(restParentLocation)));
+  }
 
-    @Test
-    public void applyBack_withParent() throws Exception {
-        //from iaas to rest
-        Location actual = locationConverter.applyBack(iaasLocation);
-        assertThat(actual, is(equalTo(restLocation)));
-    }
+  @Test
+  public void applyBack_withParent() throws Exception {
+    //from iaas to rest
+    Location actual = locationConverter.applyBack(iaasLocation);
+    assertThat(actual, is(equalTo(restLocation)));
+  }
 
-    @Test
-    public void apply_withoutParent() throws Exception {
-        //from rest to iaas
+  @Test
+  public void apply_withoutParent() throws Exception {
+    //from rest to iaas
 
-        IaasEntities.Location actual = locationConverter.apply(restParentLocation);
-        assertThat(actual, is(equalTo(iaasParentLocation)));
-    }
+    IaasEntities.Location actual = locationConverter.apply(restParentLocation);
+    assertThat(actual, is(equalTo(iaasParentLocation)));
+  }
 
-    @Test
-    public void apply_withParent() throws Exception {
-        //from rest to iaas
+  @Test
+  public void apply_withParent() throws Exception {
+    //from rest to iaas
 
-        IaasEntities.Location actual = locationConverter.apply(restLocation);
-        assertThat(actual, is(equalTo(iaasLocation)));
-    }
+    IaasEntities.Location actual = locationConverter.apply(restLocation);
+    assertThat(actual, is(equalTo(iaasLocation)));
+  }
 
 }

--- a/src/test/java/io/github/cloudiator/rest/converter/NodeCandidateConverterTest.java
+++ b/src/test/java/io/github/cloudiator/rest/converter/NodeCandidateConverterTest.java
@@ -1,0 +1,83 @@
+package io.github.cloudiator.rest.converter;
+
+import static org.junit.Assert.*;
+
+import io.github.cloudiator.rest.model.Cloud;
+import io.github.cloudiator.rest.model.Hardware;
+import io.github.cloudiator.rest.model.Image;
+import io.github.cloudiator.rest.model.Location;
+import io.github.cloudiator.rest.model.NodeCandidate;
+import org.cloudiator.messages.entities.IaasEntities;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+public class NodeCandidateConverterTest {
+
+  private final NodeCandidateConverter nodeCandidateConverter = new NodeCandidateConverter();
+  private final CloudToCloudConverterTest c2cConverterTest = new CloudToCloudConverterTest();
+  private final ImageConverterTest imageConverterTest = new ImageConverterTest();
+  private final HardwareConverterTest hwConverterTest = new HardwareConverterTest();
+  private final LocationConverterTest locationConverterTest = new LocationConverterTest();
+
+  //rest NodeCandidate
+  private final NodeCandidate restNodeCandidate;
+  private final Cloud restCloud;
+  private final Image restImage;
+  private final Hardware restHardware;
+  private final Location restLocationNoParent;
+
+  //iaas NodeCandidate
+
+  private final IaasEntities.NodeCandidate iaasNodeCandidate;
+  private final IaasEntities.Cloud iaasCloud;
+  private final IaasEntities.Image iaasImage;
+  private final IaasEntities.HardwareFlavor iaasHardware;
+  private final IaasEntities.Location iaasLocationNoParent;
+
+
+  public NodeCandidateConverterTest() {
+    //rest
+    this.restCloud = c2cConverterTest.restCloud;
+    this.restImage = imageConverterTest.restImage;
+    this.restHardware = hwConverterTest.restHardware;
+    this.restLocationNoParent = locationConverterTest.restParentLocation;
+    this.restNodeCandidate = new NodeCandidate()
+        .cloud(restCloud)
+        .image(restImage)
+        .hardware(restHardware)
+        .location(restLocationNoParent)
+        .price(123.4);
+    //iaas
+    this.iaasCloud = c2cConverterTest.iaasCloud;
+    this.iaasImage = imageConverterTest.iaasImage;
+    this.iaasHardware = hwConverterTest.iaasHardware;
+    this.iaasLocationNoParent = locationConverterTest.iaasParentLocation;
+    this.iaasNodeCandidate = IaasEntities.NodeCandidate.newBuilder()
+        .setCloud(iaasCloud)
+        .setImage(iaasImage)
+        .setHardwareFlavor(iaasHardware)
+        .setLocation(iaasLocationNoParent)
+        .setPrice(123.4)
+        .build();
+
+  }
+
+  @Test
+  public void applyBack() throws Exception {
+    //iaas to rest
+    NodeCandidate actual = nodeCandidateConverter.applyBack(iaasNodeCandidate);
+
+    assertThat(actual, is(equalTo(restNodeCandidate)));
+  }
+
+  @Test
+  public void apply() throws Exception {
+    //rest to iaas
+    IaasEntities.NodeCandidate actual = nodeCandidateConverter.apply(restNodeCandidate);
+
+    assertThat(actual, is(equalTo(iaasNodeCandidate)));
+  }
+
+}

--- a/src/test/java/io/github/cloudiator/rest/converter/NodeCandidateConverterTest.java
+++ b/src/test/java/io/github/cloudiator/rest/converter/NodeCandidateConverterTest.java
@@ -8,6 +8,7 @@ import io.github.cloudiator.rest.model.Image;
 import io.github.cloudiator.rest.model.Location;
 import io.github.cloudiator.rest.model.NodeCandidate;
 import org.cloudiator.messages.entities.IaasEntities;
+import org.cloudiator.messages.entities.MatchmakingEntities;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.*;
@@ -30,7 +31,7 @@ public class NodeCandidateConverterTest {
 
   //iaas NodeCandidate
 
-  private final IaasEntities.NodeCandidate iaasNodeCandidate;
+  private final MatchmakingEntities.NodeCandidate iaasNodeCandidate;
   private final IaasEntities.Cloud iaasCloud;
   private final IaasEntities.Image iaasImage;
   private final IaasEntities.HardwareFlavor iaasHardware;
@@ -54,7 +55,7 @@ public class NodeCandidateConverterTest {
     this.iaasImage = imageConverterTest.iaasImage;
     this.iaasHardware = hwConverterTest.iaasHardware;
     this.iaasLocationNoParent = locationConverterTest.iaasParentLocation;
-    this.iaasNodeCandidate = IaasEntities.NodeCandidate.newBuilder()
+    this.iaasNodeCandidate = MatchmakingEntities.NodeCandidate.newBuilder()
         .setCloud(iaasCloud)
         .setImage(iaasImage)
         .setHardwareFlavor(iaasHardware)
@@ -75,7 +76,7 @@ public class NodeCandidateConverterTest {
   @Test
   public void apply() throws Exception {
     //rest to iaas
-    IaasEntities.NodeCandidate actual = nodeCandidateConverter.apply(restNodeCandidate);
+    MatchmakingEntities.NodeCandidate actual = nodeCandidateConverter.apply(restNodeCandidate);
 
     assertThat(actual, is(equalTo(iaasNodeCandidate)));
   }

--- a/src/test/java/io/github/cloudiator/rest/converter/TaskConverterTest.java
+++ b/src/test/java/io/github/cloudiator/rest/converter/TaskConverterTest.java
@@ -19,8 +19,6 @@ import org.cloudiator.messages.entities.CommonEntities;
 import org.cloudiator.messages.entities.TaskEntities;
 
 
-
-
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -79,6 +77,7 @@ public class TaskConverterTest {
     //Interfaces
     this.restDockerInterface = new DockerInterface()
         .dockerImage("DockerImage");
+    this.restDockerInterface.setType(restDockerInterface.getClass().getSimpleName());
     this.iaasTaskDockerInterface = TaskEntities.TaskInterface.newBuilder()
         .setDockerInterface(
             TaskEntities.DockerInterface.newBuilder()
@@ -89,6 +88,7 @@ public class TaskConverterTest {
         .startDetection("startDetection").preStart("preStart").start("start").postStart("postStart")
         .stopDetection("stopDetection").preStop("preStop").stop("stop").postStop("postStop")
         .shutdown("shutdown");
+    this.restLanceInterface.setType(restLanceInterface.getClass().getSimpleName());
     this.iaasTaskLanceInterface = TaskEntities.TaskInterface.newBuilder()
         .setLanceInterface(
             TaskEntities.LanceInterface.newBuilder()


### PR DESCRIPTION
add NodeCandidateConverterTest
changed related TestEntities from private to public, so they can be used for NodeCandidateConverterTest.

corrected Job- and TaskConverterTest.
Now they are using TaskType correct. 